### PR TITLE
Avoid using built-in type keyword "str" as variable name.

### DIFF
--- a/earthreader/web/app.py
+++ b/earthreader/web/app.py
@@ -399,8 +399,8 @@ def tidy_generators_up():
     entry_generators = dict(generators[:10])
 
 
-def to_bool(str):
-    return str.strip().lower() == 'true'
+def to_bool(str_):
+    return str_.strip().lower() == 'true'
 
 
 def get_optional_args():


### PR DESCRIPTION
I think using `str` as variable name is not recommended.
